### PR TITLE
Fix [Golang] table border in convertSessionsToCSV function

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func convertSessionsToCSV(sessions []Session, formatOption int) (string, error) 
 	// Using tablewriter to print the table
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(headers)
-	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: true})
 	table.SetCenterSeparator("|")
 	for _, v := range csvData {
 		table.Append(v)


### PR DESCRIPTION
- [+] fix(main.go): fix table borders in convertSessionsToCSV function

![Go Table](https://github.com/H0llyW00dzZ/ChatGPT-Next-Web-Session-Exporter/assets/17626300/39a08616-8ea9-42e1-9818-63bc2064a84f)
