### PR TITLE
Fix [Golang] [Command] [Module] incorrect constant values

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,12 +24,12 @@ import (
 
 const (
 	// Output format options
-	OutputFormatCSV         = 1
-	OutputFormatDataset     = 2
-	OutputFormatInline      = 1
-	OutputFormatPerLine     = 2
-	OutputFormatSeparateCSV = 3
-	OutputFormatJSONInCSV   = 4
+	OutputFormatCSV         = exporter.FormatOptionInline // Assuming this is the inline format
+	OutputFormatDataset     = 2                           // Keep the dataset format option as is
+	OutputFormatInline      = exporter.FormatOptionInline
+	OutputFormatPerLine     = exporter.FormatOptionPerLine
+	OutputFormatSeparateCSV = exporter.OutputFormatSeparateCSVFiles // Assuming this is the separate CSV files format
+	OutputFormatJSONInCSV   = exporter.FormatOptionJSON             // Assuming this is the JSON format
 
 	// File type
 	FileTypeDataset = "dataset"
@@ -38,7 +38,7 @@ const (
 	PromptEnterJSONFilePath        = "Enter the path to the JSON file: "
 	PromptRepairData               = "Do you want to repair data? (yes/no): "
 	PromptSelectOutputFormat       = "Select the output format:\n1) CSV\n2) Hugging Face Dataset\n"
-	PromptSelectCSVOutputFormat    = "Select the message output format:\n1) Inline Formatting\n2) One Message Per Line\n3) Separate Files for Sessions and Messages\n4) JSON String in CSV\n"
+	PromptSelectCSVOutputFormat    = "Select the message output format:\n1) Inline Formatting\n2) One Message Per Line\n3) JSON String in CSV\n4) Separate Files for Sessions and Messages\n"
 	PromptEnterCSVFileName         = "Enter the name of the CSV file to save: "
 	PromptEnterSessionsCSVFileName = "Enter the name of the sessions CSV file to save: "
 	PromptEnterMessagesCSVFileName = "Enter the name of the messages CSV file to save: "
@@ -341,6 +341,7 @@ func executeCSVConversion(rfs filesystem.FileSystem, ctx context.Context, reader
 		return
 	}
 
+	// If the format option is not for separate CSV files, prompt for a single CSV file name.
 	if formatOption != OutputFormatSeparateCSV {
 		csvFileName, err = promptForInput(ctx, reader, PromptEnterCSVFileName)
 		if err != nil {
@@ -350,10 +351,12 @@ func executeCSVConversion(rfs filesystem.FileSystem, ctx context.Context, reader
 	}
 
 	switch formatOption {
-	case OutputFormatSeparateCSV:
-		createSeparateCSVFiles(rfs, ctx, reader, sessions)
 	case OutputFormatInline, OutputFormatPerLine, OutputFormatJSONInCSV:
+		// Call the function to convert sessions to a single CSV file
 		convertToSingleCSV(rfs, ctx, reader, sessions, formatOption, csvFileName)
+	case OutputFormatSeparateCSV:
+		// Call the function to create separate CSV files for sessions and messages
+		createSeparateCSVFiles(rfs, ctx, reader, sessions)
 	default:
 		bannercli.PrintTypingBanner("Invalid format option.", 100*time.Millisecond)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -53,7 +53,7 @@ func TestProcessCSVOption(t *testing.T) {
 
 	// Simulate user input by creating a reader that will return the input as if typed by a user.
 	// Assuming that the option for OutputFormatSeparateCSVFiles is 4 as per the constants defined in session.go.
-	input := fmt.Sprintf("%d\noutput_sessions.csv\noutput_messages.csv\n", 3)
+	input := fmt.Sprintf("%d\noutput_sessions.csv\noutput_messages.csv\n", 4)
 	reader := bufio.NewReader(strings.NewReader(input))
 
 	// Create a cancellable context to allow for timeout or cancellation of the process.


### PR DESCRIPTION
- [+] fix(main.go): fix incorrect constant values for OutputFormatCSV, OutputFormatInline, OutputFormatPerLine, OutputFormatSeparateCSV, OutputFormatJSONInCSV
- [+] feat(main.go): update prompt message for selecting CSV output format
- [+] feat(main.go): add condition to prompt for single CSV file name if format option is not for separate CSV files
- [+] feat(main.go): call function to convert sessions to a single CSV file if format option is for inline, per line, or JSON in CSV
- [+] feat(main.go): call function to create separate CSV files for sessions and messages if format option is for separate CSV files
- [+] fix(main_test.go): fix incorrect option value for OutputFormatSeparateCSVFiles in test case